### PR TITLE
Don't offer pip install on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,6 @@ Extract place names from a URL or text, and add context to those names -- for
 example distinguishing between a country, region or city. 
 
 
-## Install & Setup
-
-Grab the package using `pip` (this will take a few minutes)
-
-    pip install geograpy2
-
-Geograpy2 uses [NLTK](http://www.nltk.org/) for entity recognition, so you'll also need 
-to download the models we're using. Fortunately there's a command that'll take 
-care of this for you. 
-
-    geograpy-nltk
-
 ## Basic Usage
 
 Import the module, give some text or a URL, and presto.


### PR DESCRIPTION
The package isn't yet available via `pip install geograpy2`, so it confuses users more than helping.

Maybe adding instructions on how to use it from source could help - but I'm not sure how you'd do that.

See #2